### PR TITLE
Retry fails

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -84,6 +84,7 @@ export const getAllEvents = async (merklePools, genesisBlockNumber, currentBlock
     // If we don't await the response, use the sleep to throttle our calls
     // await new Promise((r) => setTimeout(r, 250));
   }
+  // retrievEvents is potentially a promise if we did not await in liue of using sleep
   const retriedEvents = await Promise.all(retriedPromises);
   allEvents = [...validResults, ...retriedEvents];
   const filteredEvents = [];

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -47,7 +47,8 @@ export const getAllEvents = async (merklePools, genesisBlockNumber, currentBlock
         );
       } catch {
         // Recursively Retry
-        retryFunction(filterItem, failedFrom, failedTo, retryNumber++);
+        const retryCount = retryNumber++;
+        retryFunction(filterItem, failedFrom, failedTo, retryCount);
       }
     } else {
       // Final retry response
@@ -62,10 +63,7 @@ export const getAllEvents = async (merklePools, genesisBlockNumber, currentBlock
    * Can't use forEach because the function would need to be async and would
    * not be able to throttle our rpc requests
    */
-  //   for (const error of invalidResults) {
   for (const [index, error] of invalidResults.entries()) {
-    const currentRetries = 0;
-    // console.log('Failed');
     if (index === Math.floor(invalidResults.length * 0.25)) {
       console.log('25% retries complete...');
     } else if (index === Math.floor(invalidResults.length * 0.5)) {
@@ -78,13 +76,13 @@ export const getAllEvents = async (merklePools, genesisBlockNumber, currentBlock
     const failedToBlock = parseInt(failedBody.params[0].toBlock, 16);
     // Using await here could take longer than our sleep below
     const newResponse = await retryFunction(filter, failedFromBlock, failedToBlock, 0);
-    // console.log(newResponse);
     retriedPromises.push(newResponse);
     // Aggressive sleep since we are retrying
     // If we don't await the response, use the sleep to throttle our calls
     // await new Promise((r) => setTimeout(r, 250));
   }
-  // retrievEvents is potentially a promise if we did not await in liue of using sleep
+
+  // retrievEvents is potentially a promise if we did not await in lieu of using sleep
   const retriedEvents = await Promise.all(retriedPromises);
   allEvents = [...validResults, ...retriedEvents];
   const filteredEvents = [];


### PR DESCRIPTION
Resolve allEvents to include valid and rejected promises. Rejected promises are then retried a max of 6 times (awaiting the result of each attempt). maxRetries + 1 since we return one more attempt as our final effort. 

This retry approach takes substantial time (especially if you have a lot of rejected promises on the first go around). Hopefully this helps people with < stellar nodes to still pull chain data if they want to wait.